### PR TITLE
feat: referral

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,14 +79,15 @@ impl Contract {
         );
         let day = env::block_timestamp_ms() / DAY_MS;
         
-        let user_amount: u128 = amount.into();
+        let amount: u128 = amount.into();
         let referral_to_mint: u128 = if referral.is_some() {
-            (user_amount / 20) as u128
+            (amount / 20) as u128
         } else {
             0
         };
+        let user_amount: u128 = amount - referral_to_mint;
         if day == self.last_mint_day {
-            self.daily_mints += user_amount;
+            self.daily_mints += amount;
             require!(
                 self.daily_mints <= self.daily_quota,
                 format!(
@@ -96,7 +97,7 @@ impl Contract {
             );
         } else {
             self.last_mint_day = day;
-            self.daily_mints = user_amount;
+            self.daily_mints = amount;
         }
 
         let user_minted = self.mint_to_user(recipient, user_amount);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use near_sdk::collections::UnorderedMap;
 use near_sdk::json_types::U128;
 use near_sdk::{env, ext_contract, log, near, require, AccountId, Gas, NearToken, PanicOnDefault};
+use std::cmp::min;
 
 mod storage;
 
@@ -68,17 +69,24 @@ impl Contract {
     //
 
     /// only minter can mint
+    /// Returns a tuple. On first index, is the amount minted to the user. In the second, the amount minted to the referral
     #[payable]
-    pub fn mint(&mut self, recipient: AccountId, amount: U128) {
+    pub fn mint(&mut self, recipient: AccountId, amount: U128, referral: Option<AccountId>) -> (u128, u128) {
         self.assert_minter();
         require!(
             env::prepaid_gas() >= Gas::from_tgas(30),
             "at least 30tgas must be attached"
         );
         let day = env::block_timestamp_ms() / DAY_MS;
-        let amount: u128 = amount.into();
+        
+        let user_amount: u128 = amount.into();
+        let referral_to_mint: u128 = if referral.is_some() {
+            (user_amount / 20) as u128
+        } else {
+            0
+        };
         if day == self.last_mint_day {
-            self.daily_mints += amount;
+            self.daily_mints += user_amount;
             require!(
                 self.daily_mints <= self.daily_quota,
                 format!(
@@ -86,37 +94,44 @@ impl Contract {
                     self.daily_mints
                 )
             );
-            require!(amount < self.user_quota, "amount above user quota");
         } else {
             self.last_mint_day = day;
-            self.daily_mints = amount;
+            self.daily_mints = user_amount;
         }
 
-        let mut minted = 0;
-        match self.user_mints.get(&recipient) {
+        let user_minted = self.mint_to_user(recipient, user_amount);
+        if referral.is_some() {
+            ext_cheddar::ext(self.cheddar.clone())
+                .with_attached_deposit(NearToken::from_yoctonear(1))
+                .ft_mint(referral.unwrap(), referral_to_mint.into(), None);    
+        }
+
+        (user_minted, referral_to_mint)
+    }
+
+    fn mint_to_user(&mut self, user: AccountId, amount: u128) -> u128 {
+        let mut user_minted = 0;
+        match self.user_mints.get(&user) {
             None => (),
             Some(x) => {
-                if x.day == day {
-                    minted = x.minted;
+                if x.day == self.last_mint_day {
+                    user_minted = x.minted;
                 }
             }
         }
-        minted += amount;
-        require!(minted <= self.user_quota, "user daily mint quota used");
+        if user_minted >= self.user_quota {
+            return 0u128;
+        }
+        
+        let amount_to_mint = min(amount, self.user_quota - user_minted);
+        user_minted += amount_to_mint;
         self.user_mints
-            .insert(&recipient, &UserDailyMint { day, minted });
+            .insert(&user, &UserDailyMint { day: self.last_mint_day, minted: user_minted });
 
         ext_cheddar::ext(self.cheddar.clone())
-            .with_attached_deposit(NearToken::from_yoctonear(1))
-            .ft_mint(recipient, amount.into(), None);
-        // ext_cheddar::ft_mint(
-        //     self.cheddar.clone(),
-        //     1.into(),
-        //     None,
-        //     &self.cheddar_id,
-        //     ONE_YOCTO,
-        //     GAS_FOR_FT_TRANSFER,
-        // );
+                .with_attached_deposit(NearToken::from_yoctonear(1))
+                .ft_mint(user, amount_to_mint.into(), None);
+        amount_to_mint
     }
 
     pub fn admin_toggle_active(&mut self) {
@@ -219,14 +234,14 @@ mod tests {
         let (mut ctx, mut ctr) = setup();
         ctx.predecessor_account_id = admin();
         testing_env!(ctx);
-        ctr.mint(alice(), 1.into())
+        ctr.mint(alice(), 1.into(), None);
     }
 
     #[test]
     fn mint() {
         let (mut ctx, mut ctr) = setup();
-        ctr.mint(alice(), 1.into());
-        ctr.mint(alice(), 9.into());
+        ctr.mint(alice(), 1.into(), None);
+        ctr.mint(alice(), 9.into(), None);
         assert_eq!(
             ctr.user_mints.get(&alice()).unwrap(),
             UserDailyMint { minted: 10, day: 1 }
@@ -234,7 +249,7 @@ mod tests {
         assert_eq!(ctr.daily_mints, 10);
         assert_eq!(ctr.last_mint_day, 1);
 
-        ctr.mint(bob(), 4.into());
+        ctr.mint(bob(), 4.into(), None);
         // recheck alice
         assert_eq!(
             ctr.user_mints.get(&alice()).unwrap(),
@@ -245,20 +260,20 @@ mod tests {
             UserDailyMint { minted: 4, day: 1 }
         );
 
-        ctr.mint(charlie(), 8.into());
+        ctr.mint(charlie(), 8.into(), None);
         assert_eq!(ctr.last_mint_day, 1);
         assert_eq!(ctr.daily_mints, 22);
 
         ctx.block_timestamp += DAY_MS * MSECOND;
         testing_env!(ctx.clone());
-        ctr.mint(alice(), 7.into());
+        ctr.mint(alice(), 7.into(), None);
         assert_eq!(ctr.daily_mints, 7);
         assert_eq!(ctr.last_mint_day, 2);
 
         // same day but a bit later
         ctx.block_timestamp += DAY_MS / 2 * MSECOND;
         testing_env!(ctx.clone());
-        ctr.mint(alice(), 2.into());
+        ctr.mint(alice(), 2.into(), None);
         assert_eq!(ctr.daily_mints, 9);
         assert_eq!(ctr.last_mint_day, 2);
         assert_eq!(
@@ -269,7 +284,7 @@ mod tests {
         // few days later
         ctx.block_timestamp += 3 * DAY_MS * MSECOND;
         testing_env!(ctx.clone());
-        ctr.mint(alice(), 2.into());
+        ctr.mint(alice(), 2.into(), None);
         assert_eq!(ctr.daily_mints, 2);
         assert_eq!(ctr.last_mint_day, 5);
         assert_eq!(
@@ -282,7 +297,7 @@ mod tests {
             UserDailyMint { minted: 4, day: 1 },
             "bob should be still in the old day"
         );
-        ctr.mint(bob(), 1.into());
+        ctr.mint(bob(), 1.into(), None);
         assert_eq!(
             ctr.user_mints.get(&bob()).unwrap(),
             UserDailyMint { minted: 1, day: 5 },
@@ -292,19 +307,29 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "user daily mint quota used")]
     fn mint_exceed_user_quota() {
         let (_, mut ctr) = setup();
-        ctr.mint(alice(), 5.into());
-        ctr.mint(alice(), 6.into());
+        ctr.mint(alice(), 5.into(), None);
+        let (user_minted, referral_minted) = ctr.mint(alice(), 6.into(), None);
+        assert_eq!(user_minted, 5);
+        assert_eq!(referral_minted, 0);
     }
 
     #[test]
     #[should_panic(expected = "total daily mint quota exceeded. Used: 24")]
     fn mint_exceed_total_quota() {
         let (_, mut ctr) = setup();
-        ctr.mint(alice(), 8.into());
-        ctr.mint(bob(), 8.into());
-        ctr.mint(charlie(), 8.into());
+        ctr.mint(alice(), 8.into(), None);
+        ctr.mint(bob(), 8.into(), None);
+        ctr.mint(charlie(), 8.into(), None);
+    }
+
+    #[test]
+    fn mint_with_referral() {
+        let (_, mut ctr) = setup();
+        let (_, referral_minted) = ctr.mint(alice(), 20.into(), Some(bob()));
+        assert_eq!(referral_minted, 1);
+        assert_eq!(ctr.user_mints.get(&alice()).unwrap().minted, 10);
+        assert_eq!(ctr.user_mints.get(&bob()).is_none(), true);
     }
 }


### PR DESCRIPTION
Regarding this task, the things I got from Blaze were:

1) Referral should always get the cheddar, even if the user that played the game has already earned their quota or the daily quota was already fulfilled
2) Fixed a but where, if the user daily quota was of 10, and the user won two games, the first one with 5 cheddar, and the second one with 6 cheddar, then the user didn't get the 10 cheddar minted. Now, if the user wins 6 cheddar on the second game, since the limit is 10, and has 5 pending, wins the 5 cheddar.